### PR TITLE
Update DoctrineBasedSagaInstanceRepository.php

### DIFF
--- a/src/DoctrineBasedSagaInstanceRepository.php
+++ b/src/DoctrineBasedSagaInstanceRepository.php
@@ -60,7 +60,7 @@ class DoctrineBasedSagaInstanceRepository extends EntityRepository implements Sa
         $sagaInstance = $this->find($sagaId);
 
         if (\is_null($sagaInstance)) {
-            throw new EntityNotFoundException('Saga instance not found. ID: %s', $sagaId);
+            throw new EntityNotFoundException(sprintf('Saga instance not found. ID: %s', $sagaId));
         }
 
         return $sagaInstance;


### PR DESCRIPTION
sagaId could be string but exception expects int. I think $sagaId is relative to exception message